### PR TITLE
Fix attempt to get length of field 'plugin_name' (a nil value)

### DIFF
--- a/lua/ansible-doc/format/doc/seealso.lua
+++ b/lua/ansible-doc/format/doc/seealso.lua
@@ -3,10 +3,12 @@ local put = require('ansible-doc.format.util').put
 
 local function put_item(bufnr, item)
 	local module = item.module
-	local parts = vim.split(module, '.', {plain=true})
-	-- NOTE: Instead of a hyperlink we should have an interactive reference
-	-- where the user can press 'K' to jump to that documentation entry.
-	put(bufnr, {string.format('    • M(%s)', module)})
+	if module then
+		local parts = vim.split(module, '.', {plain=true})
+		-- NOTE: Instead of a hyperlink we should have an interactive reference
+		-- where the user can press 'K' to jump to that documentation entry.
+		put(bufnr, {string.format('    • M(%s)', module)})
+	end
 end
 
 

--- a/plugin/ansible-doc.lua
+++ b/plugin/ansible-doc.lua
@@ -32,11 +32,13 @@ end
 
 function render_doc(params)
 	local name = params.fargs[1]
-	local doc = ansible_doc.doc(name)
+	local data = ansible_doc.doc(name)
 	local bufname = string.format('ansibledoc://%s', name)
 	local buffer, window
 	-- Whether the document is getting opened for the first time
 	local first_time = false
+
+	data.doc.plugin_name = name
 
 	-- Find previously opened buffer or create a new one
 	for _, buf in ipairs(api.nvim_list_bufs()) do
@@ -74,7 +76,7 @@ function render_doc(params)
 
 	if first_time then
 		api.nvim_set_option_value('filetype', filetype, {buf=buffer})
-		ansible_doc.render(buffer, doc)
+		ansible_doc.render(buffer, data)
 		api.nvim_set_option_value('modifiable', false, {buf=buffer})
 		api.nvim_set_option_value('readonly', true, {buf=buffer})
 		vim.keymap.set('n', 'K', follow_xref, {buffer = buffer, remap = false})


### PR DESCRIPTION
Hello,
I found that on my machine, running a rather old Ansible version (`2.12.10`) and a quite new neovim version (`0.11.0-dev`) this didn't work and was showing the error message in the PR title.